### PR TITLE
Adds selected comment folding functionality

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,4 @@
 [
-	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" }
+	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
+	{ "keys": ["ctrl+alt+c"],  "command": "toggle_fold_selected_comments" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,4 @@
 [
-	{ "keys": ["super+shift+c"], "command": "toggle_fold_comments" }
+	{ "keys": ["super+shift+c"], "command": "toggle_fold_comments" },
+	{ "keys": ["super+alt+c"], "command": "toggle_fold_selected_comments" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,4 @@
 [
-	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" }
+	{ "keys": ["ctrl+shift+c"],  "command": "toggle_fold_comments" },
+	{ "keys": ["ctrl+alt+c"],  "command": "toggle_fold_selected_comments" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -10,5 +10,9 @@
     {
         "caption": "Toggle Fold Comments",
         "command": "toggle_fold_comments"
+    },
+    {
+        "caption": "Toggle Fold Selected Comments",
+        "command": "toggle_fold_selected_comments"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Sublime Text 2/3 plugin for folding (hiding) comments
 
 ![Toggle Comment Folding](https://raw.github.com/oskarols/foldcomments/master/foldcomments.gif)
 
+As of version 0.2.0 there is also an option of folding only the selected comments!  In order to do this ctrl+click as many comments as you would like to fold.  Then press the correct keys (as shown in the keybinds section).
 
 ## Installation
 
@@ -16,16 +17,18 @@ You can install via [Sublime Package Manager](https://sublime.wbond.net/) where 
 
 ###### OSX
 Toggle Comments Folding: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
+Toggle Selected Comments Folding: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
 
 ###### Windows/Linux
 Toggle Comments Folding: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>
-
+Toggle Selected Comments Folding: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>
 
 #### Commands
 
 * `Toggle Folding Comments`
 * `Fold Comments`
 * `Unfold Comments`
+* `Toggle Folding Selected Comments`
 
 
 ## Credits

--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,0 +1,1 @@
+{"description": "Sublime Text 2/3 plugin for folding (hiding) comments", "sublime_text": "*", "platforms": ["*"], "url": "https://github.com/oskarols/foldcomments", "version": "0.2.0", "dependencies": []}


### PR DESCRIPTION
Selected comment folding, "ctrl+alt+c", can now be used to just fold
comments that are currently selected (either the cursor is within the
comment or a portion of the comment is selected).

The intialization of self.comments was changed so append could be used
in the new method for finding selected comments.  I don't think that
anything else relied upon this, but I thought it was worth noting.
Beyond that some of the functions were taken out of the init routine
just because they weren't common anymore.
